### PR TITLE
Switch to using /proc/pid/status for RSS measurement on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,7 @@ mem.inspect
 `rm tmplog`
 ```
 
-On Linux, which provides `/proc/<pid>/smaps`, the default memory type returned is PSS, or "proportional set size", where shared memory is divided by the number of processes sharing it. On other platforms, the size returned is the RSS or the [Resident Set Size](http://en.wikipedia.org/wiki/Resident_set_size), basically how much memory the program takes up in RAM at the time, including all the shared memory.
-
-The memory type can be specified by passing an options hash:
-
-```ruby
-GetProcessMem.new(Process.pid, mem_type: 'rss')
-```
-
+On Linux, for memory size we return the RSS or the [Resident Set Size](http://en.wikipedia.org/wiki/Resident_set_size), basically how much memory the program takes up in RAM at the time, including all the shared memory.
 
 
 ## License

--- a/get_process_mem.gemspec
+++ b/get_process_mem.gemspec
@@ -19,4 +19,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency "rake",  "~> 10.1"
+  gem.add_development_dependency "test-unit", "~> 3.1.0"
+
 end

--- a/lib/get_process_mem.rb
+++ b/lib/get_process_mem.rb
@@ -12,9 +12,10 @@ class GetProcessMem
   attr_reader :pid
 
   def initialize(pid = Process.pid)
+    @status_file  = Pathname.new "/proc/#{pid}/status"
     @process_file = Pathname.new "/proc/#{pid}/smaps"
     @pid          = pid
-    @linux        = @process_file.exist?
+    @linux        = @status_file.exist?
   end
 
   def linux?
@@ -22,7 +23,7 @@ class GetProcessMem
   end
 
   def bytes
-    memory =   linux_memory if linux?
+    memory =   linux_status_memory if linux?
     memory ||= ps_memory
   end
 
@@ -51,8 +52,18 @@ class GetProcessMem
     @mem_type = mem_type.downcase
   end
 
-  # linux stores memory info in a file "/proc/#{pid}/smaps"
+  # linux stores memory info in a file "/proc/#{pid}/status"
   # If it's available it uses less resources than shelling out to ps
+  def linux_status_memory(file = @status_file)
+    line = file.each_line.detect {|line| line.start_with? 'VmRSS'.freeze }
+    return unless line
+    return unless (_name, value, unit = line.split(nil)).length == 3
+    CONVERSION[unit.downcase!] * value.to_i
+  rescue Errno::EACCES, Errno::ENOENT
+    0
+  end
+
+  # linux stores detailed memory info in a file "/proc/#{pid}/smaps"
   def linux_memory(file = @process_file)
     lines = file.each_line.select {|line| line.match /^Rss/ }
     return if lines.empty?
@@ -68,11 +79,10 @@ class GetProcessMem
     0
   end
 
-  private
-
   # Pull memory from `ps` command, takes more resources and can freeze
   # in low memory situations
   def ps_memory
     KB_TO_BYTE * BigDecimal.new(`ps -o rss= -p #{pid}`)
   end
+
 end

--- a/test/fixtures/heroku-bash-status
+++ b/test/fixtures/heroku-bash-status
@@ -1,0 +1,41 @@
+Name:	bash
+State:	S (sleeping)
+Tgid:	3
+Ngid:	0
+Pid:	3
+PPid:	1
+TracerPid:	0
+Uid:	58790	58790	58790	58790
+Gid:	58790	58790	58790	58790
+FDSize:	256
+Groups:	
+VmPeak:	  109120 kB
+VmSize:	  109120 kB
+VmLck:	       0 kB
+VmPin:	       0 kB
+VmHWM:	    2032 kB
+VmRSS:	    2032 kB
+VmData:	     356 kB
+VmStk:	     136 kB
+VmExe:	     956 kB
+VmLib:	    2288 kB
+VmPTE:	      64 kB
+VmSwap:	       0 kB
+Threads:	1
+SigQ:	0/274188
+SigPnd:	0000000000000000
+ShdPnd:	0000000000000000
+SigBlk:	0000000000010000
+SigIgn:	0000000000380004
+SigCgt:	000000004b817efb
+CapInh:	0000000000000000
+CapPrm:	0000000000000000
+CapEff:	0000000000000000
+CapBnd:	0000001ff598cffe
+Seccomp:	2
+Cpus_allowed:	f
+Cpus_allowed_list:	0-3
+Mems_allowed:	00000000,00000001
+Mems_allowed_list:	0
+voluntary_ctxt_switches:	34
+nonvoluntary_ctxt_switches:	35

--- a/test/get_process_mem_test.rb
+++ b/test/get_process_mem_test.rb
@@ -19,6 +19,11 @@ class GetProcessMemTest < Test::Unit::TestCase
     assert_in_delta BigDecimal.new("2122240.0"), bytes, delta
   end
 
+  def test_linux_status
+    bytes = @mem.linux_status_memory(fixture_path("heroku-bash-status"))
+    assert_equal bytes, 2080768
+  end
+
   def test_conversions
     bytes = 0
     delta = BigDecimal.new("0.0000001")


### PR DESCRIPTION
This PR addresses #10 and uses a slightly later version of the /process/pid/status file code. The benchmarks show the same improvement over the other 2 methods. The default method for `bytes` on linux is now the `linux_status_memory` version.

The `linux_memory` method still returns the memory reported by the `smaps` file. The code that allows you to choose the mem_type was reverted (earlier) but could be added back. I also made `ps_memory` public so people could use that as well.

I needed to add a development dependency for test-unit to allow the tests to pass on Ruby 2.2.

```ruby
Benchmark.ips do |x|
  x.report('by /proc/pid/smap') { memory_self.linux_memory.to_s }
  x.report('by /proc/pid/status') { memory_self.linux_status_memory.to_s }
  x.report('by ps -o rss= -p pid') { memory_self.ps_memory.to_s }
  x.compare!
end

Calculating -------------------------------------
   by /proc/pid/smap     2.000  i/100ms
 by /proc/pid/status     1.395k i/100ms
by ps -o rss= -p pid    30.000  i/100ms
-------------------------------------------------
   by /proc/pid/smap     26.440  (±15.1%) i/s -    128.000 
 by /proc/pid/status     17.690k (±13.9%) i/s -     86.490k
by ps -o rss= -p pid    189.738  (±32.7%) i/s -    720.000  in   5.276245s

Comparison:
 by /proc/pid/status:    17689.7 i/s
by ps -o rss= -p pid:      189.7 i/s - 93.23x slower
   by /proc/pid/smap:       26.4 i/s - 669.04x slower
```
