### PR TITLE
Fix ambiguous first argument warning

### DIFF
--- a/lib/get_process_mem.rb
+++ b/lib/get_process_mem.rb
@@ -54,7 +54,7 @@ class GetProcessMem
   # linux stores memory info in a file "/proc/#{pid}/smaps"
   # If it's available it uses less resources than shelling out to ps
   def linux_memory(file = @process_file)
-    lines = file.each_line.select {|line| line.match /^Rss/ }
+    lines = file.each_line.select {|line| line.match(/^Rss/) }
     return if lines.empty?
     lines.reduce(0) do |sum, line|
       line.match(/(?<value>(\d*\.{0,1}\d+))\s+(?<unit>\w\w)/) do |m|


### PR DESCRIPTION
If you run v0.2.0 version of get_process_mem with `-w` flag will see following warning:


```
$ curl https://gist.githubusercontent.com/JuanitoFatas/e6f7f9ec8a330c52789a/raw/ac24858c6e2a56a4f618db30116300d0c9eff0e3/get_process_mem_repro.rb | ruby -w

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   167  100   167    0     0    239      0 --:--:-- --:--:-- --:--:--   239

/Users/Juan/.gem/ruby/2.2.2/gems/get_process_mem-0.2.0/lib/get_process_mem.rb:57:
warning: ambiguous first argument; put parentheses or a space even after `/' operator
```

This pull request fixes it. :blush: 

--

The gist is here: https://gist.github.com/JuanitoFatas/e6f7f9ec8a330c52789a