### PR TITLE
mem_type no longer used

### DIFF
--- a/lib/get_process_mem.rb
+++ b/lib/get_process_mem.rb
@@ -44,14 +44,6 @@ class GetProcessMem
     "#<#{self.class}:0x%08x @mb=#{ mb b } @gb=#{ gb b } @kb=#{ kb b } @bytes=#{b}>" % (object_id * 2)
   end
 
-  def mem_type
-    @mem_type
-  end
-
-  def mem_type=(mem_type)
-    @mem_type = mem_type.downcase
-  end
-
   # linux stores memory info in a file "/proc/#{pid}/status"
   # If it's available it uses less resources than shelling out to ps
   def linux_status_memory(file = @status_file)


### PR DESCRIPTION
Has been removed since ba32b5dcdd6d13eb11797a7ae80cc17628d3c55e

But the getter & setter are still there and the README still references passing an options hash to the initializer.

I can do a PR but not sure if the intention is to remove it completely or make the code use it.