### PR TITLE
Properly handle ps memory for no process in Ruby 2.4

### DIFF
--- a/lib/get_process_mem.rb
+++ b/lib/get_process_mem.rb
@@ -90,7 +90,8 @@ class GetProcessMem
       size = ProcTable.ps(pid).working_set_size
       BigDecimal.new(size)
     else
-      KB_TO_BYTE * BigDecimal.new(`ps -o rss= -p #{pid}`)
+      mem = `ps -o rss= -p #{pid}`
+      KB_TO_BYTE * BigDecimal.new(mem == "" ? 0 : mem)
     end
   end
 end


### PR DESCRIPTION
Under Ruby < 2.4, BigDecimal("") returns a 0 value,
while in Ruby 2.4 and higher it throws an exception

So we need to check to see if the shell out returns "", which is the
result is the process doesn't exist.