### PR TITLE
Silence BigDecimal deprecation warning under Ruby 2.5

### DIFF
--- a/lib/get_process_mem/version.rb
+++ b/lib/get_process_mem/version.rb
@@ -1,3 +1,3 @@
 class GetProcessMem
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end


### PR DESCRIPTION
Under Ruby 2.5, using get_process_mem emits a deprecation warning:

warning: BigDecimal.new is deprecated; use Kernel.BigDecimal method instead.