### PR TITLE
Implement faster version for Mac OS

### DIFF
--- a/get_process_mem.gemspec
+++ b/get_process_mem.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency "sys-proctable", "~> 1.0"
+  gem.add_development_dependency "ffi", "~> 1.0"
   gem.add_development_dependency "rake",  "~> 10.1"
   gem.add_development_dependency "test-unit", "~> 3.1.0"
 end

--- a/lib/get_process_mem/darwin.rb
+++ b/lib/get_process_mem/darwin.rb
@@ -1,0 +1,53 @@
+require 'ffi'
+
+class GetProcessMem
+  class Darwin
+    extend FFI::Library
+    ffi_lib 'c'
+    attach_function :mach_task_self, [], :__darwin_mach_port_t
+    attach_function :task_info,
+                    [
+                      :__darwin_mach_port_t,
+                      :int,     # return selector
+                      :pointer, #pointer to task info
+                      :pointer, #pointer to int (size of structure / bytes filled out)
+                    ],
+                    :int
+
+    class IntPtr < FFI::Struct
+      layout :value, :int
+    end
+
+    class TaskInfo < FFI::Struct
+      layout  :suspend_count, :int32,
+              :virtual_size, :uint64,
+              :resident_size, :uint64,
+              :user_time, :uint64,
+              :system_time, :uint64,
+              :policy, :int32
+    end
+
+    MACH_TASK_BASIC_INFO = 20
+    MACH_TASK_BASIC_INFO_COUNT = TaskInfo.size / FFI.type_size(:uint)
+
+    class << self
+      def resident_size
+        mach_task_info[:resident_size]
+      end
+
+      private
+
+      def mach_task_info
+        data = TaskInfo.new
+        out_count = IntPtr.new
+        out_count[:value] = MACH_TASK_BASIC_INFO_COUNT
+        result = task_info(mach_task_self, MACH_TASK_BASIC_INFO, data, out_count)
+        if result == 0
+          data
+        else
+          raise "task_info returned #{result}"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
For context see https://github.com/schneems/get_process_mem/issues/31.

This implements the approach mentioned here: https://stackoverflow.com/a/23379216/147390

Not sure about the platform selection logic - should using this codepath by compulsory for macs or should it fallback to the `ps` version ?  (but then how would people ever know to install ffi)

This seems to produce the same results in my testing as `ps`, is it worth trying to enforce that in specs ?

Lastly, not sure what needs to go into .travis.yml for specs to run against the same set of rubies but on mac os.