### PR TITLE
update development dependencies

### DIFF
--- a/get_process_mem.gemspec
+++ b/get_process_mem.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "ffi", "~> 1.0"
 
   gem.add_development_dependency "sys-proctable", "~> 1.2"
-  gem.add_development_dependency "rake",  "~> 10.1"
-  gem.add_development_dependency "test-unit", "~> 3.1.0"
+  gem.add_development_dependency "rake", "~> 12"
+  gem.add_development_dependency "test-unit", "~> 3"
 end


### PR DESCRIPTION
fixes
`
/home/travis/.rvm/gems/ruby-head/gems/rake-10.5.0/lib/rake/application.rb:381: warning: deprecated Object#=~ is called on Proc; it always returns nil
`