### PR TITLE
[close #39] Supporting different PIDs on Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master - unreleased
 
+## 0.2.6
+
+- Support returning memory from different PIDs on mac (https://github.com/schneems/get_process_mem/pull/41)
+
 ## 0.2.5
 
 - Use new sys-proctable interface (https://github.com/schneems/get_process_mem/pull/36)

--- a/lib/get_process_mem.rb
+++ b/lib/get_process_mem.rb
@@ -58,7 +58,7 @@ class GetProcessMem
 
   def bytes
     memory =   linux_status_memory if linux?
-    memory ||= darwin_memory if RUNS_ON_DARWIN
+    memory ||= darwin_memory if RUNS_ON_DARWIN && Process.pid == pid
     memory ||= ps_memory
   end
 

--- a/test/get_process_mem_test.rb
+++ b/test/get_process_mem_test.rb
@@ -1,9 +1,18 @@
 require 'test_helper'
 
 class GetProcessMemTest < Test::Unit::TestCase
-
   def setup
     @mem = GetProcessMem.new
+  end
+
+  def test_different_pid_returns_different_memory
+    pid = Process.spawn("tail -f Gemfile")
+
+    other_mem = GetProcessMem.new(pid)
+    assert @mem.kb > other_mem.kb
+  ensure
+    Process.kill('TERM', pid) if pid
+    Process.wait(pid) if pid
   end
 
   def test_seems_to_work


### PR DESCRIPTION
Currently, when you call `GetProcessMem.new` with a different pid value than the current process it calls `GetProcessMem::Darwin.resident_size this uses FFI to get data from the mach kernel about the current process.

- Origionally implemented in: https://github.com/schneems/get_process_mem/pull/32
- Based off of code from: https://stackoverflow.com/questions/18389581/memory-used-by-a-process-under-mac-os-x/23379216#23379216

This PR adds a test to ensure that memory results from different processes is correctly reported.

This PR addresses the different PID problem by checking if a different pid other than Process.pid is being passed in. If that's the case then we will fall back to determining memory based off of shelling out to `ps`.

There was a performance concern over using `Process.pid` but it appears to be relatively fast. It is approximately the speed of allocating 3 string object.

I would like to extend the FFI code to be able to quickly provide data about other processes, but I couldn't easilly figure out how to do it. I've asked on SO. If anyone knows the mach API and has hints on how to do this please let me know.