### PR TITLE
Switch from  mach task_info to proc_pidinfo

### DIFF
--- a/lib/get_process_mem.rb
+++ b/lib/get_process_mem.rb
@@ -58,7 +58,7 @@ class GetProcessMem
 
   def bytes
     memory =   linux_status_memory if linux?
-    memory ||= darwin_memory if RUNS_ON_DARWIN && Process.pid == pid
+    memory ||= darwin_memory if RUNS_ON_DARWIN
     memory ||= ps_memory
   end
 
@@ -119,6 +119,6 @@ class GetProcessMem
   end
 
   def darwin_memory
-    Darwin.resident_size
+    Darwin.resident_size(pid)
   end
 end

--- a/lib/get_process_mem.rb
+++ b/lib/get_process_mem.rb
@@ -120,5 +120,7 @@ class GetProcessMem
 
   def darwin_memory
     Darwin.resident_size(pid)
+  rescue Errno::EPERM
+    nil
   end
 end

--- a/lib/get_process_mem/darwin.rb
+++ b/lib/get_process_mem/darwin.rb
@@ -55,7 +55,7 @@ class GetProcessMem
         if result == TaskInfo.size
           data
         else
-          raise "proc_pidinfo returned #{result}, errno is #{FFI.errno}"
+          raise SystemCallError.new("proc_pidinfo returned #{result}", FFI.errno);
         end
       end
     end


### PR DESCRIPTION
The problem with the mach task_info routines is that on modern versions of
macos they require the task_for_pid-allow entitlement in order to get the
mach_task for another process (because there's all sorts of nefarious
things you can do with the mach port)

Since macos 10.5 the proc_* family of functions are a better way for getting
read-only information about processes.

This will still fail if the process is owned by another user. At the moment this raises Errno::EPERM, but should we perhaps rescue that somewhere and fall through to the next case (ps_memory)?

cc #32 #39 #41